### PR TITLE
Frontend: Implement disabling chat input with query parameter

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -16,7 +16,7 @@ The GPT-4o and similar models support uploading images. To disable this feature,
 
 To disable the entire chat input form, add `&chat_input=false` at the end of the URL when integrating it as an iframe.
 
-`https://YOUR_SIMPLE_CHAT_FRONTEND_URL/?pid=[project_id]&participant_id=[participant_id]&experiment_id=[experiment_id]&model=gpt-4o&chat_input=false&custom_system_message_id=[custom_system_message_id]`
+`https://YOUR_SIMPLE_CHAT_FRONTEND_URL/?pid=[project_id]&participant_id=[participant_id]&experiment_id=[experiment_id]&model=gpt-4o&chat_input=false&system_message_id=[custom_system_message_id]`
 
 This could be useful in combination with a custom system message that sets `assistant_first` to `true`, which makes the assistant start the conversation without waiting for user input. In this case, the participant will only see the assistant's message when loading the chat interface, and there will be no input box for the participant to type in. This setup is ideal for scenarios where the researcher wants to observe how participants react to the assistant's initial message without any influence from their own input.
 
@@ -35,7 +35,7 @@ curl --request POST \
 }'
 ```
 
-The previous example uses `YOUR_PROJECT_ID` as a placeholder for the actual project ID, and `YOUR_SIMPLE_CHAT_BACKEND_URL` as a placeholder for the actual backend URL. The `custom_system_message_id` in the frontend URL should be replaced with the ID returned from this API call.
+The previous example uses `YOUR_PROJECT_ID` as a placeholder for the actual project ID, and `YOUR_SIMPLE_CHAT_BACKEND_URL` as a placeholder for the actual backend URL. The `system_message_id` in the frontend URL should be replaced with the ID returned from this API call.
 
 ## Initiate a conversation
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -12,6 +12,31 @@ The `gpt-4o` model supports image, too. In the case you want to use `gpt-4o` wit
 
 The GPT-4o and similar models support uploading images. To disable this feature, add `&upload_image=false` at the end of the URL when integrating it as an iframe.
 
+## Hide chat input in chat interface
+
+To disable the entire chat input form, add `&chat_input=false` at the end of the URL when integrating it as an iframe.
+
+`https://YOUR_SIMPLE_CHAT_FRONTEND_URL/?pid=[project_id]&participant_id=[participant_id]&experiment_id=[experiment_id]&model=gpt-4o&chat_input=false&custom_system_message_id=[custom_system_message_id]`
+
+This could be useful in combination with a custom system message that sets `assistant_first` to `true`, which makes the assistant start the conversation without waiting for user input. In this case, the participant will only see the assistant's message when loading the chat interface, and there will be no input box for the participant to type in. This setup is ideal for scenarios where the researcher wants to observe how participants react to the assistant's initial message without any influence from their own input.
+
+Example custom system message creation with `assistant_first` set to `true`:
+
+```bash
+curl --request POST \
+  --url http://YOUR_SIMPLE_CHAT_BACKEND_URL/project/custom_system_message \
+  --header 'content-type: application/json' \
+  --data '{
+  "project_id": "YOUR_PROJECT_ID",
+  "requested_by": "myemail@provider.com",
+  "system_message": "You are a plant lover.",
+  "assistant_first": "yes",
+  "first_message": "What is your favorite plant?"
+}'
+```
+
+The previous example uses `YOUR_PROJECT_ID` as a placeholder for the actual project ID, and `YOUR_SIMPLE_CHAT_BACKEND_URL` as a placeholder for the actual backend URL. The `custom_system_message_id` in the frontend URL should be replaced with the ID returned from this API call.
+
 ## Initiate a conversation
 
 To initiate a conversation, three query parameters must be specified:

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -10,6 +10,7 @@ const ChatPage: React.FC = () => {
   const [sessionId, setSessionId] = useState("");
   const [participantId, setParticipantId] = useState("");
   const [messages, setMessages] = useState([]);
+  const [showChatInput, setShowChatInput] = useState(true);
 
   const [newMessage, setNewMessage] = useState<string>("");
   const [isTyping, setIsTyping] = useState<boolean>(true);
@@ -23,6 +24,9 @@ const ChatPage: React.FC = () => {
     let params: { [key: string]: any } = {};
     for (let [key, value] of searchParams) {
       params[key] = value;
+    }
+    if (searchParams.get("chat_input") === "false") {
+      setShowChatInput(false);
     }
     console.log("url param info: ", params);
     setUrlParams(params);
@@ -240,14 +244,16 @@ const ChatPage: React.FC = () => {
             </>
           )}
         </div>
-        <ChatInputForm
-          newMessage={newMessage}
-          handleInputChange={handleInputChange}
-          handleSubmit={handleSubmit}
-          isTyping={isTyping}
-          setImageFile={setImageFile}
-          imageFile={imageFile}
-        />
+        {showChatInput && (
+          <ChatInputForm
+            newMessage={newMessage}
+            handleInputChange={handleInputChange}
+            handleSubmit={handleSubmit}
+            isTyping={isTyping}
+            setImageFile={setImageFile}
+            imageFile={imageFile}
+          />
+        )}
       </Box>
     </>
   );

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -6,11 +6,16 @@ import { Message } from "../types";
 import BlinkingDots from "./BlinkingDots";
 import { socket } from "../socket";
 
+const shouldShowChatInput = (): boolean => {
+  const searchParams = new URLSearchParams(window.location.search);
+  return searchParams.get("chat_input") !== "false";
+};
+
 const ChatPage: React.FC = () => {
   const [sessionId, setSessionId] = useState("");
   const [participantId, setParticipantId] = useState("");
   const [messages, setMessages] = useState([]);
-  const [showChatInput, setShowChatInput] = useState(true);
+  const [showChatInput] = useState(() => shouldShowChatInput());
 
   const [newMessage, setNewMessage] = useState<string>("");
   const [isTyping, setIsTyping] = useState<boolean>(true);
@@ -24,9 +29,6 @@ const ChatPage: React.FC = () => {
     let params: { [key: string]: any } = {};
     for (let [key, value] of searchParams) {
       params[key] = value;
-    }
-    if (searchParams.get("chat_input") === "false") {
-      setShowChatInput(false);
     }
     console.log("url param info: ", params);
     setUrlParams(params);

--- a/script/destroy-dev
+++ b/script/destroy-dev
@@ -6,4 +6,4 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-docker compose --file compose.yml down --volumes
+docker compose --file compose.yml --profile dev down --volumes


### PR DESCRIPTION
Excerpt from issue description:
> The idea is to use a custom system message with assistant_first and hide the chat input with a query parameter to load Simple Chat and see only the initial assistant message in an experiment, while disabling user interaction with the model.
Fixes #4.

## Test implementation
To test these changes locally:
1. Start local Docker environment with the following terminal command
    ```sh
    ./script/start-dev
    ```
2. Open dashboard under http://localhost:3001/
3. Log in with your admin credentials defined in `.env`
4. Create a new project with _Project ID_ "test" in the dashboard
5. Create custom system message in the backend with the following terminal command after replacing `myemail@provider.com` with your email address:
    ```sh
    curl --request POST \
      --url http://localhost:8000/project/custom_system_message \
      --header 'content-type: application/json' \
      --data '{
      "project_id": "test",
      "requested_by": "myemail@provider.com",
      "system_message": "You are a plant lover.",
      "assistant_first": "yes",
      "first_message": "What is your favorite plant?"
    }'
    ```
6. Copy the `system_message_id` from the response. Example response:
    ```sh
    {"status":true,"system_message_id":"69b29024065fc19f3e7e459e"}
    ```
7. Open frontend after replacoing `69b29024065fc19f3e7e459e` with the `system_message_id` from the last response. Example:
    http://localhost:1234/?pid=test&upload_image=false&chat_input=false&assistant_first=true&system_message_id=69b29024065fc19f3e7e459e

## Result

<img width="2784" height="1634" alt="image" src="https://github.com/user-attachments/assets/f38349d3-d819-47db-9618-3b15d000dd45" />
